### PR TITLE
Add Mitiq

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ For further resources related to Open Source Quantum Software Projects, please c
 - [Blueqat](https://github.com/Blueqat/Blueqat) - Software development kit in Python for quantum gate computing.
 - [Cirq](https://github.com/quantumlib/Cirq) - Python library for writing, manipulating, and optimizing NISQ circuits to run on quantum computers.
 - [IBM Quantum Experience](https://quantum-computing.ibm.com) - Online quantum composer to run experiments on real quantum computing hardware.
+- [Mitiq](https://mitiq.readthedocs.io/) - Python toolkit for implementing error mitigation techniques on quantum computers.
 - [NISQAI](https://github.com/quantumai-lib/nisqai) - Library for performing quantum artificial intelligence on near-term quantum computers.
 - [Ocean](https://docs.ocean.dwavesys.com/en/latest/overview/install.html) - D-Wave's SDK for developing on their quantum computers using Python.
 - [Orquestra](https://www.zapatacomputing.com/orquestra/) - Zapata Computing's unified quantum operating environment, allowing for quantum-enabled workflows.


### PR DESCRIPTION
Add https://mitiq.readthedocs.io/ to the Readme. It is a Python toolkit for quantum error mitigation (beginning from zero-noise extrapolation) on noisy quantum computers, interfacing with Cirq, Qiskit, PyQuil, and openQASM. It allows to run programs on any simulator or quantum processor.