### PR TITLE
Added Quantum Computing UK

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ For further resources related to Open Source Quantum Software Projects, please c
 - [Quantum Algorithm Zoo](http://math.nist.gov/quantum/zoo/) - Comprehensive catalog of quantum algorithms. 
 - [Quantum Computer Programming](https://cs269q.stanford.edu/syllabus.html?fbclid=IwAR09_JNstMi4WVU4oMHDpWR6xWaSISlrYPjWTUTnhcRdEQhzpoOTRgQN8LI) - Hands on Stanford course teaching quantum computing to those without a quantum mechanical background.
 - [Quantum Computing Playground](http://www.quantumplayground.net/#/home) - 3D quantum state visualisation tool able to simulate up to 22 qubits.
+- [Quantum Computing UK](https://quantumcomputinguk.org/) - Free Qiskit tutorials and code repository
 - [Quantum Computing for the Very Curious](https://quantum.country/qcvc) - Essay introducing quantum computing by Michael Nielsen and Andy Matuschak.
 - [Quantum in the Cloud](http://cnotmz.appspot.com/#) - Four qubit photonic quantum simulator and computer.
 - [Quantum Katas](https://github.com/Microsoft/QuantumKatas/) - Programming exercises for learning quantum computing and Q#.


### PR DESCRIPTION
I added Quantum Computing UK to the learning section. 

We offer free Qiskit tutorials and a code repository to teach people how to program IBM's quantum devices.