### PR TITLE
Add xa0 blog.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ For further resources related to Open Source Quantum Software Projects, please c
 - [Shtetl-Optimized](https://www.scottaaronson.com/blog/) - Scott Aaronson's thoughts on quantum computing matters.
 - [The Quantum Aviary](https://thequantumaviary.blogspot.com/) - Blog without the hype talking about developments in quantum hardware. 
 - [The Quantum Daily](https://thequantumdaily.com/) - Outlet for the latest news in quantum computing, presenting articles for both research scientists and the curious Sunday newspaper reader.
+- [xa0](https://blog.xa0.de/list) - New research and deep dives into quantum computing optimization.
 
 ## Books
 - [An Introduction to Quantum Computing](https://www.amazon.com/Introduction-Quantum-Computing-Phillip-Kaye/dp/019857049X/) - Strikes an excellent balance between accessiblity and mathematical rigour. It is suitable for undergraduate students.


### PR DESCRIPTION
Hi, I work at a quantum computing startup (www.aqarios.com) and document some of my findings, new research, and sometimes do tutorials on my blog at https://blog.xa0.de/. For instance, I've listed a large number of QUBO formulations [here](https://blog.xa0.de/post/List-of-QUBO-formulations/), documented my findings on reverse-engineering QUBOs [here](https://blog.xa0.de/post/QUBO-NN%20---%20Redundancy-in-QUBOs-and-finding-different-representations-by-making-qbsolv-differentiable/), wrote on adiabatic evolution [here](https://blog.xa0.de/post/A-note-on-Adiabatic-Evolution-in-Quantum-Annealing/), and did a small tutorial on using qiskits QAOA to solve QUBOs [here](https://blog.xa0.de/post/Solving-QUBOs-with-qiskit-QAOA-example/).

I post once a month on QC topics. Some of the blog contains Machine Learning and Reinforcement Learning topics from the time when I focussed on that, but now its QC only.